### PR TITLE
chore: release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.7.1] - 2026-08-06
+
 ### Added
 
 - The entrance page is now part of the core package, at `dac/entrance.html`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ allauth = [
 ]
 
 [tool.poetry]
-version = "0.7.0"
+version = "0.7.1"
 packages = [{ include = "dac" }]
 requires-poetry = '>=2.0,<3.0'
 


### PR DESCRIPTION
Release PR for v0.7.1. Merging this PR is the release decision: the Tag Release workflow will create the `v0.7.1` tag and GitHub Release from the merge commit.