### PR TITLE
chore: update shared workflows to v0.3.2 and rename the release secret

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Auto-merge Dependabot PR
-        uses: django-mvp/shared/.github/actions/auto-merge-dependabot@v0.2.0
+        uses: django-mvp/shared/.github/actions/auto-merge-dependabot@v0.3.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-url: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   call-build:
-    uses: django-mvp/shared/.github/workflows/build.yml@v0.2.0
+    uses: django-mvp/shared/.github/workflows/build.yml@v0.3.2
     with:
       source-dir: dac
     secrets: inherit

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   call-docs:
-    uses: django-mvp/shared/.github/workflows/docs.yml@v0.2.0
+    uses: django-mvp/shared/.github/workflows/docs.yml@v0.3.2
     secrets: inherit

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -15,8 +15,8 @@ permissions:
 
 jobs:
   call-prepare-release:
-    uses: django-mvp/shared/.github/workflows/prepare-release.yml@v0.2.0
+    uses: django-mvp/shared/.github/workflows/prepare-release.yml@v0.3.2
     with:
       bump: ${{ inputs.bump }}
     secrets:
-      release-token: ${{ secrets.RELEASE_TOKEN }}
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Poetry env
-        uses: django-mvp/shared/.github/actions/setup-poetry@v0.2.0
+        uses: django-mvp/shared/.github/actions/setup-poetry@v0.3.2
         with:
           python-version: '3.13'
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -10,6 +10,6 @@ permissions:
 
 jobs:
   call-tag-release:
-    uses: django-mvp/shared/.github/workflows/tag-release.yml@v0.2.0
+    uses: django-mvp/shared/.github/workflows/tag-release.yml@v0.3.2
     secrets:
-      release-token: ${{ secrets.RELEASE_TOKEN }}
+      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   call-tests:
-    uses: django-mvp/shared/.github/workflows/tests.yml@v0.2.0
+    uses: django-mvp/shared/.github/workflows/tests.yml@v0.3.2
     with:
       coverage-package: dac
       django-versions: '["5.2", "6.0"]'


### PR DESCRIPTION
Moves every `django-mvp/shared` reference from `@v0.2.0` to `@v0.3.2` and renames the release
secret, as described in #59.

- `.github/workflows/auto-merge-dependabot.yml`
- `.github/workflows/build.yml`
- `.github/workflows/docs.yml`
- `.github/workflows/prepare-release.yml`
- `.github/workflows/publish.yml`
- `.github/workflows/tag-release.yml`
- `.github/workflows/tests.yml`

The secret rename matters more than it looks. `prepare-release` only ever read the token under
a name that reaches it through a caller's mapping, so upstream it silently fell back to
`GITHUB_TOKEN` and could not push workflow files. `release-token` is still honoured and warns,
but it will be removed once no caller passes it.

`v0.3.2` also means the `setup-poetry` action underneath these workflows is genuinely pinned.
Until it, `docs.yml` and `publish-pypi/action.yml` upstream still pointed at `@main`, so pinning
here was only half real.

`actionlint` reports nothing new against the tree before this change.

Closes #59
