### PR TITLE
chore: pin django-mvp/shared to v0.4.0

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Auto-merge Dependabot PR
-        uses: django-mvp/shared/.github/actions/auto-merge-dependabot@v0.3.2
+        uses: django-mvp/shared/.github/actions/auto-merge-dependabot@v0.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-url: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   call-build:
-    uses: django-mvp/shared/.github/workflows/build.yml@v0.3.2
+    uses: django-mvp/shared/.github/workflows/build.yml@v0.4.0
     with:
       source-dir: dac
     secrets: inherit

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   call-docs:
-    uses: django-mvp/shared/.github/workflows/docs.yml@v0.3.2
+    uses: django-mvp/shared/.github/workflows/docs.yml@v0.4.0
     secrets: inherit

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   call-prepare-release:
-    uses: django-mvp/shared/.github/workflows/prepare-release.yml@v0.3.2
+    uses: django-mvp/shared/.github/workflows/prepare-release.yml@v0.4.0
     with:
       bump: ${{ inputs.bump }}
     secrets:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Poetry env
-        uses: django-mvp/shared/.github/actions/setup-poetry@v0.3.2
+        uses: django-mvp/shared/.github/actions/setup-poetry@v0.4.0
         with:
           python-version: '3.13'
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -10,6 +10,6 @@ permissions:
 
 jobs:
   call-tag-release:
-    uses: django-mvp/shared/.github/workflows/tag-release.yml@v0.3.2
+    uses: django-mvp/shared/.github/workflows/tag-release.yml@v0.4.0
     secrets:
       RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   call-tests:
-    uses: django-mvp/shared/.github/workflows/tests.yml@v0.3.2
+    uses: django-mvp/shared/.github/workflows/tests.yml@v0.4.0
     with:
       coverage-package: dac
       django-versions: '["5.2", "6.0"]'


### PR DESCRIPTION
## Summary
- Bump every `django-mvp/shared` reusable workflow and composite action reference to `v0.4.0`.

## Test plan
- CI runs on this PR against the pinned `v0.4.0` workflows.